### PR TITLE
Changes to R evaluation notebook

### DIFF
--- a/analysis/2020_evaluate_assays.Rmd
+++ b/analysis/2020_evaluate_assays.Rmd
@@ -40,7 +40,7 @@ For each assay we calculate
 2. hits  
 3. hitrate 
 ```{r}
-response_train <- read_csv('../data/assay_matrix_discrete_train_old_scaff.csv')
+response_train <- read.csv('../predictions/assay_matrix_discrete_train_old_scaff.csv', check.names = F)
 
 values_per_assay_train <- response_train %>% 
   select(-Metadata_broad_sample_simple) %>% 
@@ -109,7 +109,7 @@ For each assay we calculate
 3. hitrate 
 ```{r}
 # response <- read_csv('../../../analysis/scaffold_based/assay_matrix_discrete_test_old_scaff.csv')
-response <- read_csv('../data/assay_matrix_discrete_test_old_scaff.csv')  
+response <- read.csv('../predictions/assay_matrix_discrete_test_old_scaff.csv', check.names = F)  
 
 values_per_assay <- response %>% 
   select(-Metadata_broad_sample_simple) %>% 
@@ -202,18 +202,9 @@ The results are stored separately for each predictor and sequetially read, evlua
 # helper function to catch test data without hits (only 0 or NA values)
 auc_with_na <- function(response, result){
   ifelse(
-    max(response >0, na.rm = TRUE) == 0,
+    all(is.na(response)) | max(response >0, na.rm = TRUE) == 0 | max(response <1, na.rm = TRUE) == 0,
     return(NA), 
     auc(response, result, direction = "<", levels = c(0, 1))
-  )
-} 
-
-# helper function to catch test data without hits (only 0 or NA values)
-prauc_with_na <- function(response, result){
-  ifelse(
-    max(response >0, na.rm = TRUE) == 0,
-    return(NA), 
-    pr.curve(response, result, direction = "<", levels = c(0, 1))
   )
 } 
 
@@ -229,17 +220,20 @@ evaluate_chemprop <- function(path_prediction) {
       ),
     descriptor = descriptor
   )
-} 
+}
+  
 ```
+
 
 ## sequentially read and evaluate predictions 
 ```{r}
 #file_list <- list.files('../../../results/scaffold_based/chemprop/predictions', pattern = "*.csv", full.names = TRUE)
-file_list <- list.files('../predictions/', pattern = "*.csv", full.names = TRUE) 
+file_list <- list.files('../predictions/predictions/', pattern = "*.csv", full.names = TRUE) 
 
 result <- do.call(rbind, lapply(file_list, evaluate_chemprop)) %>% 
-  mutate("auc_70" = auc >0.7) %>% 
-  mutate("auc_90" = auc >0.9) 
+  mutate("auc_70" = round(auc, 12) >0.7) %>% 
+  mutate("auc_90" = round(auc, 12) >0.9) 
+
 ```
 
 ## add readout count, number of hits and hit rate 
@@ -281,12 +275,13 @@ result_analyzed <- result_annotated %>%
 
 ## write all assays as csv 
 ```{r}
+result_annotated$auc <- round(result_annotated$auc, digits = 12)
 # all results 
 # result_annotated %>% write_csv("../../../results/scaffold_based/chemprop/2020_07_evaluation_all_data.csv")
-result_annotated %>% write_csv("../results/2020_07_evaluation_all_data.csv")
+result_annotated %>% write_csv("../predictions/2021_03_evaluation_all_data.csv")
 # results relevant  for analysis
 # result_analyzed %>% write_csv("../../../results/scaffold_based/chemprop/2020_07_evaluation.csv")
-result_analyzed %>% write_csv("../results/2020_07_evaluation.csv")
+result_analyzed %>% write_csv("../predictions/2021_03_evaluation.csv")
 ```
 ## Summary of predictor using AUC
 ```{r}
@@ -295,7 +290,7 @@ result %>%
   summarize(assays_total = n(),
           assays_evaluated = sum(!is.na(auc)),
           assays_not_evaluated = sum(is.na(auc)),
-          auc_mean = mean(auc, na.rm = TRUE), 
+          auc_mean = mean(auc, na.rm = TRUE),
           auc_70 = sum(auc_70, na.rm = TRUE), 
           auc_90 = sum(auc_90, na.rm = TRUE)
           ) %>% 


### PR DESCRIPTION
Hello, I was working on my Python scripts for evaluations and I was trying to produce the same evaluation results as in this R notebook. There are some problems I faced with this R notebook, so the PR proposes some changes to fix them. 

My R version is 3.6.2

Probably the best if Tim could have a look at this. 

1. I replaced `read_csv` with `read.csv` function as `read_csv` turned out to guess the type of the column values and sometimes was changing to `logical()` type which resulted in a situation that some assays could not be evaluated. Lines: [43](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR43) and [112](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR112)
2.  In the `auc_with_na` function the condition of returning `NA` for `auc` was changed. Previously it checked only if we don't have positive hits after filtering `NA` values, now it checks if the vector is complete `NA` in the first place and in addition if we have ONLY positive hits after filtering `NA`. In all that cases `NA` is returned. Line [205 ](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR205)
3. In the block which compares `auc`'s with threshold values I do rounding to 12 decimal digits. It turned out, that some `0.7` were `0.7000000000000001` (usual behaviour of float\double numbers), but in our task, it matters, because those were wrongly evaluated as values bigger than the `0.7` threshold and therefore we were getting slight overestimation for `auc_70`.  Same for `0.9`. Lines [234](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR234) and [235](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR235)
4. Related to 3, last output to CSV block, rounding `auc` column so we won't get  `0.7000000000000001` in the CSV file. Line [278](https://github.com/carpenterlab/puma_project/compare/fix_R_code?expand=1#diff-d5b92f15b77206185d3b008f4b0d539d8c7040e10951e2f7d0ab7e924e31881cR278)
