### PR TITLE
Transformation of morphological features

### DIFF
--- a/analysis/PUMA_feature_transform.ipynb
+++ b/analysis/PUMA_feature_transform.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import umap\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sb\n",
+    "import scipy.linalg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Load features from population.csv file\n",
+    "population_df = pd.read_csv('/raid/data/PUMA/cdr/population.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Load broad compound ids which are used in the current PUMA experiments\n",
+    "broad_ids_df = pd.read_csv('broad_ids.txt', header = None)\n",
+    "broad_ids = broad_ids_df.loc[:,0].to_list()\n",
+    "len(broad_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter population.csv, leave only compounds from PUMA experiment + DMSO\n",
+    "population_df_filtered = population_df[ (population_df[\"Metadata_broad_sample\"] == \"DMSO\") | (population_df[\"Metadata_pert_id\"].isin(broad_ids)) ].reset_index(drop=True).copy()\n",
+    "population_df_filtered"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Get lists of feature column names\n",
+    "feature_columns = population_df_filtered.columns[17:-1].tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class WhiteningNormalizer(object):\n",
+    "    def __init__(self, controls):\n",
+    "        REG_PARAM = 10**np.log(1/controls.shape[0])\n",
+    "        # Whitening transform on population level data\n",
+    "        self.mu = controls.mean()\n",
+    "        self.whitening_transform(controls - self.mu, REG_PARAM, rotate=True)\n",
+    "        print(self.mu.shape, self.W.shape)\n",
+    "        \n",
+    "    def whitening_transform(self, X, lambda_, rotate=True):\n",
+    "        C = (1/X.shape[0]) * np.dot(X.T, X)\n",
+    "        s, V = scipy.linalg.eigh(C)\n",
+    "        D = np.diag( 1. / np.sqrt(s + lambda_) )\n",
+    "        W = np.dot(V, D)\n",
+    "        if rotate:\n",
+    "            W = np.dot(W, V.T)\n",
+    "        self.W = W\n",
+    "\n",
+    "    def normalize(self, X):\n",
+    "        return np.dot(X - self.mu, self.W)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Start whitening\n",
+    "whN = WhiteningNormalizer(population_df_filtered.loc[population_df_filtered[\"Metadata_broad_sample\"] == \"DMSO\", feature_columns])\n",
+    "whD = whN.normalize(population_df_filtered[feature_columns])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Replace original feature values with feature values after whitening\n",
+    "population_df_filtered[feature_columns] = whD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Mean aggregation\n",
+    "aggregated_whitened = population_df_filtered[['Metadata_broad_sample', 'Metadata_Plate_Map_Name', 'Metadata_pert_id'] + feature_columns].copy()\n",
+    "aggregated_whitened = aggregated_whitened.groupby(\"Metadata_broad_sample\").mean().reset_index()\n",
+    "\n",
+    "aggregated_whitened_np = aggregated_whitened[aggregated_whitened['Metadata_broad_sample'] != 'DMSO'].to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Save features. Those should be preprocessed later (sorted in the same way as in other experiments, remove first column)\n",
+    "np.savez('aggregated_whitened_morphology_features', features=aggregated_whitened_np)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Get UMAP plot of aggregated features after whitening\n",
+    "reducer = umap.UMAP()\n",
+    "embeddings = reducer.fit_transform(aggregated_whitened_np[:,1:])\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.scatter(x=embeddings[:,0], y=embeddings[:,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Make a dataframe of UMAP embeddings\n",
+    "embeddings = np.concatenate((embeddings, np.reshape(aggregated_whitened_np[:,0],(aggregated_whitened_np[:,0].size, 1))), axis=1)\n",
+    "embeddings_df = pd.DataFrame(embeddings, columns = ['X', 'Y', 'Metadata_broad_sample']) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Merge embeddings dataframe with other metadata\n",
+    "temp = population_df_filtered[['Metadata_broad_sample', 'Metadata_Plate_Map_Name', 'Metadata_pert_id']].copy()\n",
+    "temp = temp.groupby(['Metadata_broad_sample', 'Metadata_Plate_Map_Name', 'Metadata_pert_id'], as_index=False).size().reset_index(name = \"Count\").drop(columns = [\"Count\"])\n",
+    "embeddings_full_df = pd.merge(embeddings_df.reset_index(drop=True), temp , on=\"Metadata_broad_sample\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "embeddings_full_df.to_csv('aggregated_umap_python_whitening.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/analysis/PUMA_feature_transform.ipynb
+++ b/analysis/PUMA_feature_transform.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "# Load features from population.csv file\n",
-    "population_df = pd.read_csv('/raid/data/PUMA/cdr/population.csv')"
+    "population_df = pd.read_csv('/raid/data/PUMA/cdr/population_normalized.csv')"
    ]
   },
   {
@@ -61,7 +61,13 @@
    "outputs": [],
    "source": [
     "#Get lists of feature column names\n",
-    "feature_columns = population_df_filtered.columns[17:-1].tolist()"
+    "feature_columns = population_df_filtered.columns[20:].tolist()\n",
+    "nan_columns = []\n",
+    "for i in feature_columns:\n",
+    "    if population_df_filtered[i].isnull().values.any():\n",
+    "        nan_columns.append(i)\n",
+    "\n",
+    "feature_columns = list(set(feature_columns) - set(nan_columns))"
    ]
   },
   {
@@ -140,7 +146,7 @@
    "outputs": [],
    "source": [
     "# Save features. Those should be preprocessed later (sorted in the same way as in other experiments, remove first column)\n",
-    "np.savez('aggregated_whitened_morphology_features', features=aggregated_whitened_np)"
+    "np.savez('aggregated_whitened_morphology_features_norm', features=aggregated_whitened_np)"
    ]
   },
   {
@@ -191,7 +197,7 @@
    },
    "outputs": [],
    "source": [
-    "embeddings_full_df.to_csv('aggregated_umap_python_whitening.csv')"
+    "embeddings_full_df.to_csv('aggregated_umap_python_whitening_norm.csv')"
    ]
   },
   {


### PR DESCRIPTION
Hello,
Here is the notebook which does whitening transformation of the morphological features.

1. Original features are taken from `population.csv`. 
2. For transformation only compounds from other chemprop experiments are used, those are in `broad_ids.txt` file, which is not committed here (but I can commit it here if needed). I also removed the problematic compound `BRD-K52850071` from this list. 
3. Besides compounds, I use all controls from the dataset `'Metadata_broad_sample' == "DMSO"`
4. Whitening transformation code is the same  in DeepProfiler experiments (for TA-ORF) by @jccaicedo . 
`REG_PARAM = 10**np.log(1/controls.shape[0])`
5. Mean aggregation of transformed features by `Metadata_broad_sample`.

The screenshot of the UMAP plot of aggregated features:
![aggregated_features](https://user-images.githubusercontent.com/3052376/112663781-83d5ea00-8e59-11eb-9359-ff278a4f565b.PNG)

HTML file of the above plot:
[aggregated_umap.zip](https://github.com/carpenterlab/puma_project/files/6213220/aggregated_umap.zip)